### PR TITLE
Add missing lifecycleState

### DIFF
--- a/TMF664-ResourceFunctionActivation-v4.0.0.swagger.json
+++ b/TMF664-ResourceFunctionActivation-v4.0.0.swagger.json
@@ -4314,7 +4314,8 @@
       "description": "A ResourceFunction is a behavior to transform inputs of any nature into outputs of any nature independently from the way it is provided.",
       "required": [
         "href",
-        "id"
+        "id",
+        "lifecycleState"
       ],
       "properties": {
         "id": {
@@ -4324,6 +4325,10 @@
         "href": {
           "type": "string",
           "description": "The URI for the object itself."
+        },
+        "lifecycleState": {
+          "type": "string",
+          "description": "The life cycle state of the resource."
         },
         "category": {
           "type": "string",
@@ -4474,12 +4479,17 @@
       "description": "A ResourceFunction is a behavior to transform inputs of any nature into outputs of any nature independently from the way it is provided.\nSkipped properties: id,href",
       "required": [
         "name",
-        "resourceSpecification"
+        "resourceSpecification",
+        "lifecycleState"
       ],
       "properties": {
         "category": {
           "type": "string",
           "description": "Category of the concrete resource. e.g Gold, Silver for MSISDN concrete resource"
+        },
+        "lifecycleState": {
+          "type": "string",
+          "description": "The life cycle state of the resource."
         },
         "description": {
           "type": "string",
@@ -4632,6 +4642,10 @@
         "description": {
           "type": "string",
           "description": "free-text description of the resource"
+        },
+        "lifecycleState": {
+          "type": "string",
+          "description": "The life cycle state of the resource."
         },
         "endOperatingDate": {
           "type": "string",


### PR DESCRIPTION
According to https://tmf-open-api-table-documents.s3.eu-west-1.amazonaws.com/OpenApiTable/4.0.0/user_guides/TMF664_Resource_Function_Activation_Management_API_REST_Specification_R19.5.0.pdf and the conformance test-tool, the field "lifecycleState" is a (mandatory) member of ResourceFunction and its corresponding create object.